### PR TITLE
fix: missing entries from sw precache manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.0.0",
 		"@typescript-eslint/parser": "^6.0.0",
 		"@vite-pwa/assets-generator": "^0.0.11",
-		"@vite-pwa/sveltekit": "^0.2.9",
+		"@vite-pwa/sveltekit": "^0.2.10",
 		"eslint": "^8.28.0",
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-svelte": "^2.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ devDependencies:
     specifier: ^0.0.11
     version: 0.0.11
   '@vite-pwa/sveltekit':
-    specifier: ^0.2.9
-    version: 0.2.9(@sveltejs/kit@1.27.7)(vite-plugin-pwa@0.16.7)
+    specifier: ^0.2.10
+    version: 0.2.10(@sveltejs/kit@1.27.7)(vite-plugin-pwa@0.16.7)
   eslint:
     specifier: ^8.28.0
     version: 8.55.0
@@ -1952,8 +1952,8 @@ packages:
       unconfig: 0.3.11
     dev: true
 
-  /@vite-pwa/sveltekit@0.2.9(@sveltejs/kit@1.27.7)(vite-plugin-pwa@0.16.7):
-    resolution: {integrity: sha512-O/aH/0fj0r5D3+w2P5jrRzp1RcqoQeWJ/GXvaSvuv57KdGS/yO5eOkzsE60r/pLySVcwOtvwgKaseWS9Ct8uaA==}
+  /@vite-pwa/sveltekit@0.2.10(@sveltejs/kit@1.27.7)(vite-plugin-pwa@0.16.7):
+    resolution: {integrity: sha512-58acO/8vL7tVqBNH6IZnB34b2TLco39AF3wN41FEevrxUoM9BNY5VNZAKG2va4LPnzbeB8svSKhZjYGZ34aJQQ==}
     engines: {node: '>=16.14 || >=18'}
     peerDependencies:
       '@sveltejs/kit': ^1.3.1

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,9 @@ export default defineConfig({
 					}
 				]
 			},
+			injectManifest: {
+				globPatterns: ['client/**/*.{js,css,html,svg,png,json,ico}']
+			},
 			devOptions: {
 				enabled: process.env.ENABLE_DEV_PWA === 'true',
 				suppressWarnings: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,8 +62,12 @@ export default defineConfig({
 					}
 				]
 			},
-			injectManifest: {
-				globPatterns: ['client/**/*.{js,css,html,svg,png,json,ico}']
+			// in case you need to include some other file extensions, remember to add client/ prefix
+			// injectManifest: {
+			// 	globPatterns: ['client/**/*.{js,css,html,svg,png,json,ico}']
+			// },
+			kit: {
+				includeVersionFile: true
 			},
 			devOptions: {
 				enabled: process.env.ENABLE_DEV_PWA === 'true',


### PR DESCRIPTION
I need to add some hint about `globPatterns` in pwa docs ;).

I'm releasing new kit pwa version with a new option to include the version.json file.